### PR TITLE
[Master] Add (barely) FreeBSD build support and update documentation, and potentially improve portability for other UNIX-like platforms

### DIFF
--- a/GIAN07/FONTUTY.CPP
+++ b/GIAN07/FONTUTY.CPP
@@ -75,7 +75,7 @@ void TextBackend_GDICleanup(void)
 	RemoveFontResourceExW(FONT_MODERN, FR_PRIVATE, 0);
 #endif
 }
-#elif defined(LINUX)
+#elif defined(LINUX) || defined(FREEBSD)
 #define GOTHIC "MS Gothic,IPAMonaGothic "
 
 extern constinit const ENUMARRAY<const char *, FONT_ID> FontSpecs = {

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ On Linux:
 ./build_linux.sh             # builds both Debug and Release binaries
 ```
 
-On FreeBSD (remember that building [Tup](https://github.com/gittup/tup) from source is highly recommended, it has been only tested with Gcc16 so far, building on Clang is currently broken):
+On FreeBSD (you may need to build [Tup](https://github.com/gittup/tup) from source, building with Clang is currently not supported):
 
 ```sh
 ./build_freebsd.sh bin/GIAN07  # builds only the Release binary

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ On Linux:
 ./build_linux.sh             # builds both Debug and Release binaries
 ```
 
+On FreeBSD (remember that building [Tup](https://github.com/gittup/tup) from source is highly recommended, it has been only tested with Gcc16 so far, building on Clang is currently broken):
+
+```sh
+./build_freebsd.sh bin/GIAN07  # builds only the Release binary
+./build_freebsd.sh bin/GIAN07d # builds only the Debug binary
+./build_freebsd.sh             # builds both Debug and Release binaries
+```
+
 ## Debugging (Windows only)
 
 .PDB files are generated for Debug and Release builds, so you should get symbol support with any Windows debugger.

--- a/Tupfile.freebsd.lua
+++ b/Tupfile.freebsd.lua
@@ -1,0 +1,49 @@
+tup.import("TOOLCHAIN=gcc")
+tup.include("libs/tupblocks/toolchain." .. TOOLCHAIN .. ".lua")
+tup.include("libs/BLAKE3.lua")
+
+-- Same pkg-config-driven approach as Linux. FreeBSD ports provide .pc files
+-- for all of these, so there's no need to hardcode include/link paths here.
+local PLATFORM_LINK = EnvConfig("sdl3", "pangocairo", "fontconfig")
+local LAYERS_LINK = EnvConfig("libwebp", "ogg", "vorbis", "vorbisfile")
+local BLAKE3_LINK = (EnvConfig("libblake3") or BuildBLAKE3(CONFIG, 0))
+
+-- Since Pango/Cairo adds -pthread to a later configuration, the C++ standard
+-- library must also be compiled with this flag.
+CONFIG = CONFIG:branch({ cflags = "-pthread", lflags = "-pthread" })
+
+-- Static linking the GCC runtime, since the FreeBSD GCC ports don't put their
+-- libstdc++/libgcc into the default ldconfig search path.
+CONFIG = CONFIG:branch({ lflags = { "-static-libstdc++", "-static-libgcc" } })
+
+local ssg_cfg = CONFIG:branch(
+	BLAKE3_LINK, LAYERS_LINK, SSG_COMPILE, CONFIG:cxx_std_modules(), {
+		-- NOTE: intentionally *not* -DLINUX. If platform/c/file.cpp (or
+		-- anything else) special-cases LINUX for something that isn't
+		-- actually Linux-specific, that's the real bug to fix there, not
+		-- something to paper over here.
+		cflags = { "-DFREEBSD", "-DSDL3=1" },
+	}
+)
+local ssg_obj = ssg_cfg:cxx(SSG_SRC)
+
+-- Our platform layer code
+LAYERS_SRC += (SSG.glob("platform/c/*.cpp"))
+ssg_obj = (ssg_obj + ssg_cfg:cxx(LAYERS_SRC))
+
+local platform_cfg = ssg_cfg:branch(PLATFORM_LINK)
+local platform_src = SSG.glob("platform/sdl/*.cpp")
+platform_src += SSG.glob("platform/miniaudio/*.cpp")
+platform_src += SSG.glob("platform/pangocairo/*.cpp")
+platform_src += "MAIN/main_sdl.cpp"
+platform_src.extra_inputs += PLATFORM_CONSTANTS
+ssg_obj = (
+	ssg_obj +
+	platform_cfg:cxx(platform_src) +
+
+	-- Clang does not like C being compiled with clang++, and non-C++ clang
+	-- does not like module-related switches.
+	CONFIG:branch(SSG_COMPILE):cc(SSG.glob("platform/miniaudio/*.c"))
+)
+
+platform_cfg:exe(ssg_obj, "GIAN07")

--- a/build_freebsd.sh
+++ b/build_freebsd.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+ 
+bash ./version_from_git.sh
+ 
+[ ! -d .tup ] && tup init
+
+# Unlike on Linux, we do NOT enable full_deps here: it requires running 
+# sub-processes in a chroot with Linux namespaces for complete dependency 
+# tracking outside the project tree. Linux namespaces is a feature exclusive 
+# to that kernel: The BSDs use other technologies for containerized environments
+# but Tup doesn't seem to support them.
+
+./submodules_check.sh \
+	libs/tupblocks \
+	libs/dr_libs \
+	libs/miniaudio \
+	|| exit 1
+ 
+. ./libs/tupblocks/tupblocks.sh
+ 
+pkg_config_env_required \
+	sdl3 \
+	fontconfig \
+	libwebp \
+	ogg \
+	pangocairo \
+	vorbis \
+	vorbisfile \
+ 
+pkg_config_env_optional libblake3
+! pkg-config --exists libblake3 && {
+	./submodules_check.sh libs/BLAKE3 || exit 1;
+}
+
+# Unlike on Linux, we do not trust that `g++`/`gcc` will resolve to the 
+# correct compiler: on FreeBSD, they can point to any version of lang/gcc* 
+# installed as default, not necessarily the one that supports the 
+# C++ Standard Library Modules we require.
+: "${CC:=gcc16}"
+: "${CXX:=g++16}"
+export CC CXX
+
+export TOOLCHAIN=gcc
+tup "$@"

--- a/build_freebsd.sh
+++ b/build_freebsd.sh
@@ -32,13 +32,59 @@ pkg_config_env_optional libblake3
 	./submodules_check.sh libs/BLAKE3 || exit 1;
 }
 
-# Unlike on Linux, we do not trust that `g++`/`gcc` will resolve to the 
-# correct compiler: on FreeBSD, they can point to any version of lang/gcc* 
-# installed as default, not necessarily the one that supports the 
-# C++ Standard Library Modules we require.
-: "${CC:=gcc16}"
-: "${CXX:=g++16}"
+# Unlike on Linux, we do not trust that `g++`/`gcc` will resolve to the
+# correct compiler: on FreeBSD they can point to whatever lang/gcc* port is
+# installed as the system default, not necessarily one that supports the
+# C++ Standard Library Modules we require (GCC >14).
+#
+# GCC 15 is deliberately avoided where possible: there ara known GCC 15 compiler errors that make this ssg fail to build. We scan for the newest
+# available g++NN >14 (excluding 15) first, and only fall back to 15 (with
+# a warning) if nothing newer is installed.
+if [ -z "$CXX" ]; then
+	best=""
+	best_ver=0
+	for candidate in /usr/local/bin/g++[0-9]*; do
+		[ -x "$candidate" ] || continue
+		ver="${candidate##*g++}"
+		case "$ver" in
+			''|*[!0-9]*) continue ;; # not a clean numeric suffix
+		esac
+		[ "$ver" -le 14 ] && continue # doesn't support std modules
+		[ "$ver" -eq 15 ] && continue # known GCC 15 module bug, skip for now
+		if [ "$ver" -gt "$best_ver" ]; then
+			best_ver="$ver"
+			best="$candidate"
+		fi
+	done
+ 
+	# Fallback: only use GCC 15 if nothing newer was found above.
+	if [ -z "$best" ] && [ -x /usr/local/bin/g++15 ]; then
+		>&2 echo "Warning: only GCC 15 was found, which has a known bug"
+		>&2 echo "affecting this project. Install lang/gcc16 or newer if possible."
+		best=/usr/local/bin/g++15
+		best_ver=15
+	fi
+ 
+	if [ -z "$best" ]; then
+		>&2 echo "No g++NN >14 found in /usr/local/bin/."
+		>&2 echo "Install lang/gcc16 (or newer) via pkg/ports, or export"
+		>&2 echo "CC/CXX manually pointing to a suitable compiler."
+		exit 1
+	fi
+	CXX="$best"
+	CC=$(echo "$best" | sed 's/g++/gcc/')
+	echo "Using detected toolchain: CXX=$CXX CC=$CC"
+fi
 export CC CXX
-
+ 
+# tupblocks.sh's automatic toolchain detector looks literally for "*GCC*"
+# (uppercase) in the first line of `$CXX --version`. The GCC banner on the
+# FreeBSD Ports Collection is:
+#
+#   g++x (FreeBSD Ports Collection) xx.x.x
+#
+# ...with no "GCC" substring anywhere, so the detector fails for any GCC
+# installed via pkg/ports. This appears to be a bug in tupblocks itself  not something specific to ssg. In the meantime, we
+# skip automatic detection entirely: we already know it's GCC, also CLang is currently broken on other UNIX-like systems.
 export TOOLCHAIN=gcc
 tup "$@"

--- a/platform/c/file.cpp
+++ b/platform/c/file.cpp
@@ -15,24 +15,29 @@
 #include "platform/file.h"
 
 struct FILE_TIMESTAMPS_C : public FILE_TIMESTAMPS {
-	statx_timestamp mtime;
+	struct timespec mtime;
 };
 
 std::unique_ptr<FILE_TIMESTAMPS> File_TimestampsGet(const char8_t *fn)
 {
 	const auto *s = std::bit_cast<const char *>(fn);
 
+#ifdef LINUX
 	struct statx stx;
 	if(statx(AT_FDCWD, s, 0, STATX_MTIME, &stx) == 0) {
-		FILE_TIMESTAMPS_C ret = { .mtime = stx.stx_mtime };
+		FILE_TIMESTAMPS_C ret = {
+			.mtime = { .tv_sec = stx.stx_mtime.tv_sec,
+			           .tv_nsec = stx.stx_mtime.tv_nsec }
+		};
 		return std::unique_ptr<FILE_TIMESTAMPS_C>(
 			new (std::nothrow) FILE_TIMESTAMPS_C(ret)
 		);
 	}
+#endif
 
 	struct stat st;
 	if(stat(s, &st) == 0) {
-		FILE_TIMESTAMPS_C ret = { .mtime = { .tv_sec = st.st_mtime } };
+		FILE_TIMESTAMPS_C ret = { .mtime = st.st_mtim };
 		return std::unique_ptr<FILE_TIMESTAMPS_C>(
 			new (std::nothrow) FILE_TIMESTAMPS_C(ret)
 		);

--- a/platform/text_backend.h
+++ b/platform/text_backend.h
@@ -21,7 +21,7 @@ template <class T> concept TEXTRENDER_SESSION_PIXELACCESS_BASE = requires(
 
 #ifdef WIN32
 #include "platform/windows/text_gdi.h"
-#elif defined(LINUX)
+#elif defined(LINUX) || defined(FREEBSD)
 #include "platform/pangocairo/text_pangocairo.h"
 #endif
 


### PR DESCRIPTION
Very self-explained, the game now build and runs on this platform in an almost identical way to Linux.
<img width="993" height="667" alt="imagen" src="https://github.com/user-attachments/assets/6500b2bd-f57f-4a05-bd8c-66aac9836a34" />

### Known issues:

- Only GCC has been tested, Clang currently doesn't work because of a [known issue on the FreeBSD Clang/LLVM packages and the Clang version included in the base system](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289746#c1). There should be workarounds for this because this is also true for other UNIX-like platforms that are not Linux (I don't know if this issue also happens on musl based Linux distros tho).
- Tup doesn't work consistently on other UNIX-like platforms compared to other more widely used build systems and "build system generators", for example in the BSDs the user need to build Tup from source and enable the FUSE modules manually, and the support for FUSE is fragmented across those systems, so that's something to take into consideration, usually, on OpenBSD and NetBSD, the standard procedure when the port maintainers encounter a project using Tup is to bypass the build system entirely and convert all the existing Tup rules to BSD Make or write a BSD Makefile from scratch. So, this task could be delegated to the maintainers, and if necessary, the process can be documented to make the porting process to platforms that don't support Tup more seamless.
- ~~in-game there's a noticeable lag in audio compared to the Linux build.~~ Fixed in https://github.com/Renkoto/ssg/commit/17d6fa06258e1a9b148c1c9ce828caf67578e65f

whether if there are other [linuxisms](https://people.freebsd.org/~olivierd/porters-handbook/dads-avoiding-linuxisms.html) and windowsims in the codebase that may cause this game to behave differently on other platforms is unknown to me, you are free to check and make any modifications if this for some reason break the build process on the other platforms, in general as long as platform-specific idiosincrasias are avoided (or isolated) Shouusou Gyoku should be 100% portable to any platform that is POSIX compliant, `ssg` already uses SDL and other libraries that are cross-platform, so achieving "that" should be a cakewalk.